### PR TITLE
Add simple usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@
 | **BUDY_USERNAME** | `str` | `None`                       | The username to be used for authentication.                                                                              |
 | **BUDY_PASSWORD** | `str` | `None`                       | The password to be user for authentication.                                                                              |
 
+## Example
+
+```python
+import budy
+
+api = budy.API(
+    username="my_user",
+    password="my_password"
+)
+
+api.login()
+api.create_voucher_value(10)
+```
+
 ## License
 
 Budy API is currently licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/).


### PR DESCRIPTION
## Summary
- add an example that demonstrates how to instantiate the Budy API, log in and create a voucher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3f7dd62c8328a0a40602bb475b98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an example usage section to the README, demonstrating how to use the module with Python code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->